### PR TITLE
upload bytelength fix.

### DIFF
--- a/src/bot/commands/emote/add.ts
+++ b/src/bot/commands/emote/add.ts
@@ -60,7 +60,7 @@ export class EmoteAdd extends Command {
 
     const resizedImage = await extractImageBuffer(url);
 
-    if (resizedImage && resizedImage.buf.byteLength > 256_000) {
+    if (resizedImage && resizedImage.buf.byteLength >  262_144 ) {
       throw new UserError("Emote is too large (max 256kb)");
     }
 


### PR DESCRIPTION
262_144 is the actual byte length discord checks against. 

Your optimizer settings suck for things already optimized but that's besides the point.